### PR TITLE
Add fast Docker layer caching to CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -3,15 +3,68 @@ name: Docker Image CI
 on: [push]
 
 jobs:
-  build:
+  build_test_project:
     runs-on: ubuntu-latest
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
     steps:
     - uses: actions/checkout@v2
-    - name: Build colonists-shared
-      run: docker build --tag colonists/colonists-shared:$(git log --pretty=format:'%h' -n 1) --build-arg BRANCH_TAG=$(git log --pretty=format:'%h' -n 1) ./colonists-shared
-    - name: Build colonists-server
-      run: docker build --tag colonists/colonists-server:$(git log --pretty=format:'%h' -n 1) --build-arg BRANCH_TAG=$(git log --pretty=format:'%h' -n 1) ./colonists-server
-    - name: Build colonists-client
-      run: docker build --tag colonists/colonists-client:$(git log --pretty=format:'%h' -n 1) --build-arg BRANCH_TAG=$(git log --pretty=format:'%h' -n 1) ./colonists-client
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+      with:
+          driver-opts: network=host
+    - name: Set colonists-shared cache
+      uses: actions/cache@v2
+      with:
+        path: /tmp/.buildx-cache-shared
+        key: ${{ runner.os }}-buildx-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-buildx-
+    - name: Set colonists-server cache
+      uses: actions/cache@v2
+      with:
+        path: /tmp/.buildx-cache-server
+        key: ${{ runner.os }}-buildx-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-buildx-
+    - name: Set colonists-client cache
+      uses: actions/cache@v2
+      with:
+        path: /tmp/.buildx-cache-client
+        key: ${{ runner.os }}-buildx-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-buildx-
+    - name: Build shared
+      uses: docker/build-push-action@v2
+      with:
+        push: true
+        tags: localhost:5000/colonists/colonists-shared
+        cache-from: type=local,src=/tmp/.buildx-cache-shared
+        cache-to: type=local,dest=/tmp/.buildx-cache-shared
+        context: ./colonists-shared
     - name: Run shared tests
-      run: docker run --rm colonists/colonists-shared:$(git log --pretty=format:'%h' -n 1)
+      run: docker run --rm localhost:5000/colonists/colonists-shared
+    - name: Build server
+      uses: docker/build-push-action@v2
+      with:
+        push: false
+        tags: colonists/colonists-server
+        cache-from: type=local,src=/tmp/.buildx-cache-server
+        cache-to: type=local,dest=/tmp/.buildx-cache-server
+        context: ./colonists-server
+        build-args: |
+          "LOCAL_REGISTRY=localhost:5000/"
+    - name: Build client
+      uses: docker/build-push-action@v2
+      with:
+        push: false
+        tags: colonists/colonists-client
+        cache-from: type=local,src=/tmp/.buildx-cache-client
+        cache-to: type=local,dest=/tmp/.buildx-cache-client
+        context: ./colonists-client
+        build-args: |
+          "LOCAL_REGISTRY=localhost:5000/"
+        

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -23,6 +23,24 @@ jobs:
         key: ${{ runner.os }}-buildx-${{ github.sha }}
         restore-keys: |
           ${{ runner.os }}-buildx-
+    - name: Build shared
+      uses: docker/build-push-action@v2
+      with:
+        push: true
+        tags: localhost:5000/colonists/colonists-shared
+        cache-from: type=local,src=/tmp/.buildx-cache-shared
+        cache-to: type=local,dest=/tmp/.buildx-cache-shared-new
+        context: ./colonists-shared
+    -
+        # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        name: Limit shared cache size
+        run: |
+          rm -rf /tmp/.buildx-cache-shared
+          mv /tmp/.buildx-cache-shared-new /tmp/.buildx-cache-shared
+    - name: Run shared tests
+      run: docker run --rm localhost:5000/colonists/colonists-shared
     - name: Set colonists-server cache
       uses: actions/cache@v2
       with:
@@ -30,6 +48,24 @@ jobs:
         key: ${{ runner.os }}-buildx-${{ github.sha }}
         restore-keys: |
           ${{ runner.os }}-buildx-
+    - name: Build server
+      uses: docker/build-push-action@v2
+      with:
+        push: false
+        tags: colonists/colonists-server
+        cache-from: type=local,src=/tmp/.buildx-cache-server
+        cache-to: type=local,dest=/tmp/.buildx-cache-server-new
+        context: ./colonists-server
+        build-args: |
+          "LOCAL_REGISTRY=localhost:5000/"
+    -
+        # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        name: Limit server cache size
+        run: |
+          rm -rf /tmp/.buildx-cache-server
+          mv /tmp/.buildx-cache-server-new /tmp/.buildx-cache-server
     - name: Set colonists-client cache
       uses: actions/cache@v2
       with:
@@ -37,34 +73,21 @@ jobs:
         key: ${{ runner.os }}-buildx-${{ github.sha }}
         restore-keys: |
           ${{ runner.os }}-buildx-
-    - name: Build shared
-      uses: docker/build-push-action@v2
-      with:
-        push: true
-        tags: localhost:5000/colonists/colonists-shared
-        cache-from: type=local,src=/tmp/.buildx-cache-shared
-        cache-to: type=local,dest=/tmp/.buildx-cache-shared
-        context: ./colonists-shared
-    - name: Run shared tests
-      run: docker run --rm localhost:5000/colonists/colonists-shared
-    - name: Build server
-      uses: docker/build-push-action@v2
-      with:
-        push: false
-        tags: colonists/colonists-server
-        cache-from: type=local,src=/tmp/.buildx-cache-server
-        cache-to: type=local,dest=/tmp/.buildx-cache-server
-        context: ./colonists-server
-        build-args: |
-          "LOCAL_REGISTRY=localhost:5000/"
     - name: Build client
       uses: docker/build-push-action@v2
       with:
         push: false
         tags: colonists/colonists-client
         cache-from: type=local,src=/tmp/.buildx-cache-client
-        cache-to: type=local,dest=/tmp/.buildx-cache-client
+        cache-to: type=local,dest=/tmp/.buildx-cache-client-new
         context: ./colonists-client
         build-args: |
           "LOCAL_REGISTRY=localhost:5000/"
-        
+    -
+        # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        name: Limit server cache size
+        run: |
+          rm -rf /tmp/.buildx-cache-client
+          mv /tmp/.buildx-cache-client-new /tmp/.buildx-cache-client

--- a/colonists-client/Dockerfile
+++ b/colonists-client/Dockerfile
@@ -1,6 +1,7 @@
 # Library
 ARG BRANCH_TAG=latest
-FROM colonists/colonists-shared:${BRANCH_TAG} as library
+ARG LOCAL_REGISTRY=
+FROM ${LOCAL_REGISTRY}colonists/colonists-shared:${BRANCH_TAG} as library
 
 # Cache
 FROM node:alpine as dependency-cache-client

--- a/colonists-server/Dockerfile
+++ b/colonists-server/Dockerfile
@@ -1,5 +1,6 @@
 ARG BRANCH_TAG=latest
-FROM colonists/colonists-shared:${BRANCH_TAG} as library
+ARG LOCAL_REGISTRY
+FROM ${LOCAL_REGISTRY}colonists/colonists-shared:${BRANCH_TAG} as library
 
 FROM node as dependency-cache-server
 WORKDIR /cache


### PR DESCRIPTION
This is done using Docker's own released actions in combination with GitHub's caching actions.
A local package registry is used, and has been added to `Dockerfile`s as `ARG`s.
These `ARG`s do not interfere with local Docker builds in my testing.