### PR TITLE
Refactor Helper.ts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -3,15 +3,68 @@ name: Docker Image CI
 on: [push]
 
 jobs:
-  build:
+  build_test_project:
     runs-on: ubuntu-latest
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
     steps:
     - uses: actions/checkout@v2
-    - name: Build colonists-shared
-      run: docker build --tag colonists/colonists-shared:$(git log --pretty=format:'%h' -n 1) --build-arg BRANCH_TAG=$(git log --pretty=format:'%h' -n 1) ./colonists-shared
-    - name: Build colonists-server
-      run: docker build --tag colonists/colonists-server:$(git log --pretty=format:'%h' -n 1) --build-arg BRANCH_TAG=$(git log --pretty=format:'%h' -n 1) ./colonists-server
-    - name: Build colonists-client
-      run: docker build --tag colonists/colonists-client:$(git log --pretty=format:'%h' -n 1) --build-arg BRANCH_TAG=$(git log --pretty=format:'%h' -n 1) ./colonists-client
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+      with:
+          driver-opts: network=host
+    - name: Set colonists-shared cache
+      uses: actions/cache@v2
+      with:
+        path: /tmp/.buildx-cache-shared
+        key: ${{ runner.os }}-buildx-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-buildx-
+    - name: Set colonists-server cache
+      uses: actions/cache@v2
+      with:
+        path: /tmp/.buildx-cache-server
+        key: ${{ runner.os }}-buildx-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-buildx-
+    - name: Set colonists-client cache
+      uses: actions/cache@v2
+      with:
+        path: /tmp/.buildx-cache-client
+        key: ${{ runner.os }}-buildx-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-buildx-
+    - name: Build shared
+      uses: docker/build-push-action@v2
+      with:
+        push: true
+        tags: localhost:5000/colonists/colonists-shared
+        cache-from: type=local,src=/tmp/.buildx-cache-shared
+        cache-to: type=local,dest=/tmp/.buildx-cache-shared
+        context: ./colonists-shared
     - name: Run shared tests
-      run: docker run --rm colonists/colonists-shared:$(git log --pretty=format:'%h' -n 1)
+      run: docker run --rm localhost:5000/colonists/colonists-shared
+    - name: Build server
+      uses: docker/build-push-action@v2
+      with:
+        push: false
+        tags: colonists/colonists-server
+        cache-from: type=local,src=/tmp/.buildx-cache-server
+        cache-to: type=local,dest=/tmp/.buildx-cache-server
+        context: ./colonists-server
+        build-args: |
+          "LOCAL_REGISTRY=localhost:5000/"
+    - name: Build client
+      uses: docker/build-push-action@v2
+      with:
+        push: false
+        tags: colonists/colonists-client
+        cache-from: type=local,src=/tmp/.buildx-cache-client
+        cache-to: type=local,dest=/tmp/.buildx-cache-client
+        context: ./colonists-client
+        build-args: |
+          "LOCAL_REGISTRY=localhost:5000/"
+        

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -23,6 +23,24 @@ jobs:
         key: ${{ runner.os }}-buildx-${{ github.sha }}
         restore-keys: |
           ${{ runner.os }}-buildx-
+    - name: Build shared
+      uses: docker/build-push-action@v2
+      with:
+        push: true
+        tags: localhost:5000/colonists/colonists-shared
+        cache-from: type=local,src=/tmp/.buildx-cache-shared
+        cache-to: type=local,dest=/tmp/.buildx-cache-shared-new
+        context: ./colonists-shared
+    -
+        # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        name: Limit shared cache size
+        run: |
+          rm -rf /tmp/.buildx-cache-shared
+          mv /tmp/.buildx-cache-shared-new /tmp/.buildx-cache-shared
+    - name: Run shared tests
+      run: docker run --rm localhost:5000/colonists/colonists-shared
     - name: Set colonists-server cache
       uses: actions/cache@v2
       with:
@@ -30,6 +48,24 @@ jobs:
         key: ${{ runner.os }}-buildx-${{ github.sha }}
         restore-keys: |
           ${{ runner.os }}-buildx-
+    - name: Build server
+      uses: docker/build-push-action@v2
+      with:
+        push: false
+        tags: colonists/colonists-server
+        cache-from: type=local,src=/tmp/.buildx-cache-server
+        cache-to: type=local,dest=/tmp/.buildx-cache-server-new
+        context: ./colonists-server
+        build-args: |
+          "LOCAL_REGISTRY=localhost:5000/"
+    -
+        # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        name: Limit server cache size
+        run: |
+          rm -rf /tmp/.buildx-cache-server
+          mv /tmp/.buildx-cache-server-new /tmp/.buildx-cache-server
     - name: Set colonists-client cache
       uses: actions/cache@v2
       with:
@@ -37,34 +73,21 @@ jobs:
         key: ${{ runner.os }}-buildx-${{ github.sha }}
         restore-keys: |
           ${{ runner.os }}-buildx-
-    - name: Build shared
-      uses: docker/build-push-action@v2
-      with:
-        push: true
-        tags: localhost:5000/colonists/colonists-shared
-        cache-from: type=local,src=/tmp/.buildx-cache-shared
-        cache-to: type=local,dest=/tmp/.buildx-cache-shared
-        context: ./colonists-shared
-    - name: Run shared tests
-      run: docker run --rm localhost:5000/colonists/colonists-shared
-    - name: Build server
-      uses: docker/build-push-action@v2
-      with:
-        push: false
-        tags: colonists/colonists-server
-        cache-from: type=local,src=/tmp/.buildx-cache-server
-        cache-to: type=local,dest=/tmp/.buildx-cache-server
-        context: ./colonists-server
-        build-args: |
-          "LOCAL_REGISTRY=localhost:5000/"
     - name: Build client
       uses: docker/build-push-action@v2
       with:
         push: false
         tags: colonists/colonists-client
         cache-from: type=local,src=/tmp/.buildx-cache-client
-        cache-to: type=local,dest=/tmp/.buildx-cache-client
+        cache-to: type=local,dest=/tmp/.buildx-cache-client-new
         context: ./colonists-client
         build-args: |
           "LOCAL_REGISTRY=localhost:5000/"
-        
+    -
+        # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        name: Limit server cache size
+        run: |
+          rm -rf /tmp/.buildx-cache-client
+          mv /tmp/.buildx-cache-client-new /tmp/.buildx-cache-client

--- a/colonists-client/Dockerfile
+++ b/colonists-client/Dockerfile
@@ -1,6 +1,7 @@
 # Library
 ARG BRANCH_TAG=latest
-FROM colonists/colonists-shared:${BRANCH_TAG} as library
+ARG LOCAL_REGISTRY=
+FROM ${LOCAL_REGISTRY}colonists/colonists-shared:${BRANCH_TAG} as library
 
 # Cache
 FROM node:alpine as dependency-cache-client

--- a/colonists-client/src/components/Player.vue
+++ b/colonists-client/src/components/Player.vue
@@ -454,7 +454,7 @@
 
 <script lang="ts">
 import { Component, Vue, Watch } from 'vue-property-decorator';
-import { DiceRollType, Player as PlayerState, TileType } from '../../../colonists-shared/dist/Shared';
+import { DiceRoll, Player as PlayerState, TileType } from '../../../colonists-shared/dist/Shared';
 import Trade from './Trade.vue';
 import { EndTurnAction, BuyCardAction, UndoAction, PlayCardAction } from '../../../colonists-shared/dist/Action';
 import { DevelopmentCardType } from '../../../colonists-shared/dist/Entities/DevelopmentCard';
@@ -476,7 +476,7 @@ export default class Player extends Vue {
   }
 
   public setIsMovingThief (): void {
-    if ((this.$store.state.game.world.currentDie as DiceRollType) === 7) {
+    if ((this.$store.state.game.world.currentDie as DiceRoll) === 7) {
       this.$store.commit('ui/setIsMovingThief', true);
     }
   }

--- a/colonists-client/src/store/modules/game.ts
+++ b/colonists-client/src/store/modules/game.ts
@@ -8,7 +8,7 @@ import {
   Result,
   Tile,
   Action,
-  DiceRollType,
+  DiceRoll,
   GameState,
   success,
   toResultInstance,
@@ -49,7 +49,7 @@ const getters: GetterTree<State, unknown> = {
     }
     return state.world.players[state.world.currentPlayer];
   },
-  getCurrentDie(state: State): DiceRollType {
+  getCurrentDie(state: State): DiceRoll {
     if (!state.world) {
       return undefined;
     }

--- a/colonists-server/Dockerfile
+++ b/colonists-server/Dockerfile
@@ -1,5 +1,6 @@
 ARG BRANCH_TAG=latest
-FROM colonists/colonists-shared:${BRANCH_TAG} as library
+ARG LOCAL_REGISTRY
+FROM ${LOCAL_REGISTRY}colonists/colonists-shared:${BRANCH_TAG} as library
 
 FROM node as dependency-cache-server
 WORKDIR /cache

--- a/colonists-shared/.eslintrc.js
+++ b/colonists-shared/.eslintrc.js
@@ -28,7 +28,7 @@ module.exports = {
     'no-redeclare': 0,
     'no-unused-vars': 0,
     'no-use-before-define': 0,
-    'no-warning-comments': [1, { terms: ['todo', 'fixme'], location: 'anywhere' }],
+    'no-warning-comments': [1, { terms: ['todo', 'fixme', 'warn'], location: 'anywhere' }],
     'object-literal-sort-keys': 0,
     'operator-linebreak': 0,
     'ordered-imports': 0,

--- a/colonists-shared/__tests__/building.spec.ts
+++ b/colonists-shared/__tests__/building.spec.ts
@@ -1,5 +1,5 @@
-import { placeCity, placeHouse } from "../lib/Rules/Helpers";
-import { GameStatistics, House, Player, Road, success, World } from "../lib/Shared";
+import { BuildHouseAction, BuildCityAction } from "../lib/Action";
+import { GameStatistics, House, Player, Road, success, rules, World } from "../lib/Shared";
 
 /*
 * Building
@@ -8,7 +8,8 @@ describe('Building rules', () => {
   
     test('Building a house without a road leading to it is not allowed', () => {
       const p1: Player = new Player('P1');
-  
+      p1.resources = {wood: 100, stone: 100, wool: 100, grain: 100, clay: 100}
+
       const w: World = {
         currentDie: 'None',
         currentPlayer: 0,
@@ -16,7 +17,7 @@ describe('Building rules', () => {
         players: [p1],
         winner: undefined,
         pointsToWin: 0,
-        gameState: 'Uninitialized',
+        gameState: 'Started',
         gameStatistics: new GameStatistics(),
         version: 0,
         gameRules: {
@@ -28,13 +29,17 @@ describe('Building rules', () => {
           rounds: 0,
         },
       };
-  
-      const resultOnSamePlayer = placeHouse({x: 1, y: 2})('P1')(w);
-      expect(resultOnSamePlayer).toHaveProperty('reason');
+
+      const initialResult = success(w);
+      const rule = rules.BuildHouse(new BuildHouseAction('P1', {x: 1, y: 2}));
+      const applied = rule(initialResult);
+
+      expect(applied).toHaveProperty('reason');
     });
   
     test('Building a house with a road leading to it is allowed', () => {
       const p1: Player = new Player('P1');
+      p1.resources = {wood: 100, stone: 100, wool: 100, grain: 100, clay: 100}
   
       const w: World = {
         currentDie: 'None',
@@ -43,7 +48,7 @@ describe('Building rules', () => {
         players: [p1],
         winner: undefined,
         pointsToWin: 0,
-        gameState: 'Uninitialized',
+        gameState: 'Started',
         gameStatistics: new GameStatistics(),
         version: 0,
         gameRules: {
@@ -58,16 +63,21 @@ describe('Building rules', () => {
   
       p1.roads = [new Road({x: 0, y: 0}, {x: 1, y: 1})]
   
-      const resultOnSamePlayer = placeHouse({x: 1, y: 1})('P1')(w);
-      expect(resultOnSamePlayer).not.toHaveProperty('reason');
+      const initialResult = success(w);
+      const rule = rules.BuildHouse(new BuildHouseAction('P1', {x: 1, y: 1}));
+      const applied = rule(initialResult);
+      
+      expect(applied).not.toHaveProperty('reason');
     });
   
     test('Building a house where there are neighboring houses is not allowed', () => {
       const p1: Player = new Player('P1');
       p1.houses = [new House({x: 0, y: 0})];
+      p1.resources = {wood: 100, stone: 100, wool: 100, grain: 100, clay: 100}
   
       const p2: Player = new Player('P2');
-      p1.houses = [new House({x: 4, y: 4})];
+      p2.houses = [new House({x: 4, y: 4})];
+      p2.resources = {wood: 100, stone: 100, wool: 100, grain: 100, clay: 100}
   
       const w: World = {
         currentDie: 'None',
@@ -76,7 +86,7 @@ describe('Building rules', () => {
         players: [p1, p2],
         winner: undefined,
         pointsToWin: 0,
-        gameState: 'Uninitialized',
+        gameState: 'Started',
         gameStatistics: new GameStatistics(),
         version: 0,
         gameRules: {
@@ -89,16 +99,20 @@ describe('Building rules', () => {
         },
       };
       
-      const resultOnSamePlayer = placeHouse({x: 1, y: 2})('P1')(w);
-      expect(resultOnSamePlayer).toHaveProperty('reason');
+      const initialResult = success(w);
+      const rule1 = rules.BuildHouse(new BuildHouseAction('P1', {x: 1, y: 2}));
+      const applied1 = rule1(initialResult);
+      expect(applied1).toHaveProperty('reason');
   
-      const resultOnOtherPlayer = placeHouse({x: 5, y: 5})('P1')(w);
-      expect(resultOnOtherPlayer).toHaveProperty('reason');
+      const rule2 = rules.BuildHouse(new BuildHouseAction('P1', {x: 5, y: 5}));
+      const applied2 = rule2(initialResult);
+      expect(applied2).toHaveProperty('reason');
     });
   
     test('Building a house where there are no neighboring houses is allowed', () => {
       const p1: Player = new Player('P1');
       p1.roads = [new Road({x: 0, y: 0}, {x: 1, y: 1})]
+      p1.resources = {wood: 100, stone: 100, wool: 100, grain: 100, clay: 100}
   
       const w: World = {
         currentDie: 'None',
@@ -107,7 +121,7 @@ describe('Building rules', () => {
         players: [p1],
         winner: undefined,
         pointsToWin: 0,
-        gameState: 'Uninitialized',
+        gameState: 'Started',
         gameStatistics: new GameStatistics(),
         version: 0,
         gameRules: {
@@ -120,14 +134,17 @@ describe('Building rules', () => {
         },
       };
       
-      const resultOnSamePlayer = placeHouse({x: 1, y: 1})('P1')(w);
-      expect(resultOnSamePlayer).not.toHaveProperty('reason');
+      const initialResult = success(w);
+      const rule = rules.BuildHouse(new BuildHouseAction('P1', {x: 1, y: 1}));
+      const applied = rule(initialResult);
+      expect(applied).not.toHaveProperty('reason');
     });
   
     test('Building a house increases points for the player building the house', () => {
       const p1: Player = new Player('P1');
       p1.roads = [new Road({x: 0, y: 0}, {x: 1, y: 1})]
       p1.points = 0;
+      p1.resources = {wood: 100, stone: 100, wool: 100, grain: 100, clay: 100}
   
       const w: World = {
         currentDie: 'None',
@@ -136,7 +153,7 @@ describe('Building rules', () => {
         players: [p1],
         winner: undefined,
         pointsToWin: 0,
-        gameState: 'Uninitialized',
+        gameState: 'Started',
         gameStatistics: new GameStatistics(),
         version: 0,
         gameRules: {
@@ -149,9 +166,11 @@ describe('Building rules', () => {
         },
       };
       
-      const resultOnSamePlayer = placeHouse({x: 1, y: 1})('P1')(w);
-      expect(resultOnSamePlayer).not.toHaveProperty('reason');
-      expect(resultOnSamePlayer.flatMap((w: World) => {
+      const initialResult = success(w);
+      const rule = rules.BuildHouse(new BuildHouseAction('P1', {x: 1, y: 1}));
+      const applied = rule(initialResult);
+      expect(applied).not.toHaveProperty('reason');
+      expect(applied.flatMap((w: World) => {
         expect(w.players.some((p: Player) => p.points === 1)); 
         return success(w)
       }));
@@ -160,6 +179,7 @@ describe('Building rules', () => {
     test('Building a city with an existing house is allowed', () => {
       const p1: Player = new Player('P1');
       p1.houses = [new House({x: 0, y: 0})];
+      p1.resources = {wood: 100, stone: 100, wool: 100, grain: 100, clay: 100}
   
       const w: World = {
         currentDie: 'None',
@@ -168,7 +188,7 @@ describe('Building rules', () => {
         players: [p1],
         winner: undefined,
         pointsToWin: 0,
-        gameState: 'Uninitialized',
+        gameState: 'Started',
         gameStatistics: new GameStatistics(),
         version: 0,
         gameRules: {
@@ -181,9 +201,11 @@ describe('Building rules', () => {
         },
       };
       
-      const resultOnSamePlayer = placeCity({x: 0, y: 0})('P1')(w);
-      expect(resultOnSamePlayer).not.toHaveProperty('reason');
-      expect(resultOnSamePlayer.flatMap((w: World) => {
+      const initialResult = success(w);
+      const rule = rules.BuildCity(new BuildCityAction('P1', {x: 0, y: 0}));
+      const applied = rule(initialResult);
+      expect(applied).not.toHaveProperty('reason');
+      expect(applied.flatMap((w: World) => {
         expect(w.players.every((p: Player) => p.cities.length === 1 && p.cities.every((c => c.position === {x: 0, y: 0})))); 
         return success(w)
       }));
@@ -191,6 +213,7 @@ describe('Building rules', () => {
   
     test('Building a city without an existing house is not allowed', () => {
       const p1: Player = new Player('P1');
+      p1.resources = {wood: 100, stone: 100, wool: 100, grain: 100, clay: 100}
   
       const w: World = {
         currentDie: 'None',
@@ -199,7 +222,7 @@ describe('Building rules', () => {
         players: [p1],
         winner: undefined,
         pointsToWin: 0,
-        gameState: 'Uninitialized',
+        gameState: 'Started',
         gameStatistics: new GameStatistics(),
         version: 0,
         gameRules: {
@@ -212,17 +235,21 @@ describe('Building rules', () => {
         },
       };
       
-      const resultOnSamePlayer = placeCity({x: 0, y: 0})('P1')(w);
-      expect(resultOnSamePlayer.flatMap((w: World) => {
+      const initialResult = success(w);
+      const rule = rules.BuildCity(new BuildCityAction('P1', {x: 0, y: 0}));
+      const applied = rule(initialResult);
+      
+      expect(applied.flatMap((w: World) => {
         expect(w.players.every((p: Player) => p.cities.length === 0)); 
         return success(w)
       }));
-      expect(resultOnSamePlayer).toHaveProperty('reason');
+      expect(applied).toHaveProperty('reason');
     });
   
     test('Building a city increases points for the player building the city', () => {
       const p1: Player = new Player('P1');
       p1.houses = [new House({x: 0, y: 0})];
+      p1.resources = {wood: 100, stone: 100, wool: 100, grain: 100, clay: 100}
   
       const w: World = {
         currentDie: 'None',
@@ -231,7 +258,7 @@ describe('Building rules', () => {
         players: [p1],
         winner: undefined,
         pointsToWin: 0,
-        gameState: 'Uninitialized',
+        gameState: 'Started',
         gameStatistics: new GameStatistics(),
         version: 0,
         gameRules: {
@@ -244,11 +271,13 @@ describe('Building rules', () => {
         },
       };
   
-      const resultOnSamePlayer = placeCity({x: 0, y: 0})('P1')(w);
-      expect(resultOnSamePlayer.flatMap((w: World) => {
+      const initialResult = success(w);
+      const rule = rules.BuildCity(new BuildCityAction('P1', {x: 0, y: 0}));
+      const applied = rule(initialResult);
+      expect(applied.flatMap((w: World) => {
         expect(w.players.every((p: Player) => p.points === 1)); 
         return success(w)
       }));
-      expect(resultOnSamePlayer).not.toHaveProperty('reason');
+      expect(applied).not.toHaveProperty('reason');
     });
   });

--- a/colonists-shared/lib/Rules/BuildHouse.ts
+++ b/colonists-shared/lib/Rules/BuildHouse.ts
@@ -1,6 +1,6 @@
 import { Result } from './Result';
 import { ensureGameState, findPlayer, purchase, placeHouse, increasePointsForPlayer } from './Helpers';
-import { House } from '../Shared';
+import { HexCoordinate, House, Player } from '../Shared';
 import { BuildHouseAction } from '../Action';
 
 export const BuildHouse = ({ parameters }: BuildHouseAction) => (
@@ -9,5 +9,9 @@ export const BuildHouse = ({ parameters }: BuildHouseAction) => (
   .flatMap(ensureGameState('Started'))
   .flatMap(findPlayer(parameters.playerName))
   .flatMap(purchase(new House().cost)(parameters.playerName))
-  .flatMap(placeHouse(parameters.coordinates)(parameters.playerName))
+  .flatMap(placeHouse(parameters.coordinates)(parameters.playerName)(hasRoad))
   .flatMap(increasePointsForPlayer(parameters.playerName));
+
+const hasRoad = (coord: HexCoordinate, p: Player) => p.roads.some(
+  (r) => (r.start.x === coord.x && r.start.y === coord.y) || (r.end.x === coord.x && r.end.y === coord.y),
+);

--- a/colonists-shared/lib/Rules/BuildHouseInitial.ts
+++ b/colonists-shared/lib/Rules/BuildHouseInitial.ts
@@ -1,9 +1,9 @@
 import { BuildHouseInitialAction } from '../Action';
-import { World, Result, fail, success } from '../Shared';
+import { World, Result, fail, success, HexCoordinate, Player } from '../Shared';
 import { ensureGameState,
   findPlayer,
-  placeHouseInital,
-  increasePointsForPlayer } from './Helpers';
+  increasePointsForPlayer,
+  placeHouse } from './Helpers';
 
 const checkNumberOfStructures = (w: World): Result => {
   const round = Math.floor(w.gameStatistics.turns / w.players.length);
@@ -19,7 +19,7 @@ const checkNumberOfStructures = (w: World): Result => {
     return fail(
       `You cannot place a ${ordinal(
         currentPlayer.houses.length + 1,
-      )} house in the ${ordinal(round + 1)} pre-game round!`,
+      )} house in the ${ordinal(round + 1)} pre-game round`,
     );
   }
   return success(w);
@@ -33,5 +33,7 @@ export const BuildHouseInitial = ({ parameters }: BuildHouseInitialAction) => (
     .flatMap(ensureGameState('Pregame'))
     .flatMap((w: World) => checkNumberOfStructures(w))
     .flatMap(findPlayer(parameters.playerName))
-    .flatMap(placeHouseInital(parameters.coordinates)(parameters.playerName))
+    .flatMap(placeHouse(parameters.coordinates)(parameters.playerName)(hasRoad))
     .flatMap(increasePointsForPlayer(parameters.playerName));
+
+const hasRoad = (coordinate: HexCoordinate, p: Player) => true;

--- a/colonists-shared/lib/Rules/BuyCard.ts
+++ b/colonists-shared/lib/Rules/BuyCard.ts
@@ -1,6 +1,6 @@
 import { BuyCardAction } from '../Action';
-import { Result, purchase } from '../Shared';
-import { ensureGameState, findPlayer, assignDevelopmentCard } from './Helpers';
+import { Result, purchase, World, success, fail } from '../Shared';
+import { ensureGameState, findPlayer } from './Helpers';
 import { DevelopmentCard } from '../Entities/DevelopmentCard';
 
 export const BuyCard = ({ parameters }: BuyCardAction) => (w: Result): Result => w
@@ -8,3 +8,16 @@ export const BuyCard = ({ parameters }: BuyCardAction) => (w: Result): Result =>
   .flatMap(findPlayer(parameters.playerName))
   .flatMap(purchase(new DevelopmentCard().cost)(parameters.playerName))
   .flatMap(assignDevelopmentCard(parameters.playerName));
+
+const assignDevelopmentCard = (playerName: string) => (w: World): Result => {
+  const randomCard = new DevelopmentCard();
+  const player = w.players.find((pl) => pl.name === playerName);
+  if (!player) return fail(`The player ${playerName} was not found`);
+  const newCards = player.devCards.concat(randomCard);
+  const players = w.players.map((pl) => (pl.name === playerName ? {
+    ...pl, devCards: newCards,
+  } : pl));
+  return success({
+    ...w, players,
+  });
+};

--- a/colonists-shared/lib/Rules/EndTurn.ts
+++ b/colonists-shared/lib/Rules/EndTurn.ts
@@ -1,10 +1,8 @@
 import { EndTurnAction } from '../Action';
 import { Result, success, fail } from './Result';
 import { World } from '../World';
-import { findPlayer,
-  assignNextPlayerTurn,
-  assignInitalRessourcesToPlayers } from './Helpers';
-import { GameState } from '../Shared';
+import { findPlayer, assignNextPlayerTurn, assignRessourcesToPlayers } from './Helpers';
+import { GameState, Tile } from '../Shared';
 
 export const EndTurn = ({ parameters }: EndTurnAction) => (
   world: Result,
@@ -27,9 +25,9 @@ const checkVictory = (playerName: string) => (w: World) => {
 
 const verifyThief = (w: World) => {
   if (w.currentDie !== 7) return success(w);
-  if (!w.thief && w.lastThiefPosition) return fail('You have to move the Thief this turn!');
+  if (!w.thief && w.lastThiefPosition) return fail('You have to move the Thief this turn');
   if (w.thief && w.lastThiefPosition && w.thief.hexCoordinate !== w.lastThiefPosition.hexCoordinate) {
-    return fail('You have to move the Thief this turn!');
+    return fail('You have to move the Thief this turn');
   }
   return success(w);
 };
@@ -37,8 +35,11 @@ const verifyThief = (w: World) => {
 const stateChanger = (w: World): Result => {
   const round = Math.floor(w.gameStatistics.turns / w.players.length);
   if (round === 2 && w.gameState === 'Pregame') {
-    const players = assignInitalRessourcesToPlayers(w);
-    // initial resources
+    const initialFilter = (tile: Tile) =>
+      w.gameState === 'Pregame'
+      && !(w.thief && w.thief.hexCoordinate.x === tile.coord.x && w.thief.hexCoordinate.y === tile.coord.y);
+
+    const players = assignRessourcesToPlayers(w, initialFilter);
     const gameState: GameState = 'Started';
     return success({
       ...w, gameState, players,

--- a/colonists-shared/lib/Rules/HarborTrade.ts
+++ b/colonists-shared/lib/Rules/HarborTrade.ts
@@ -1,10 +1,9 @@
 import { HarborTradeAction } from '../Action';
-import { Result } from '../Shared';
+import { Resources, Result, World, fail, success, neighbouringHexCoords } from '../Shared';
+import { HarborType } from '../Tile';
 import { findPlayer,
   hasResources,
-  transferResources,
-  resourcesMatchHarbor,
-  playerHasHarbor } from './Helpers';
+  transferResources } from './Helpers';
 
 export const HarborTrade = ({ parameters }: HarborTradeAction) => (
   w: Result,
@@ -20,3 +19,40 @@ export const HarborTrade = ({ parameters }: HarborTradeAction) => (
       parameters.receive,
     ),
   );
+
+const resourcesMatchHarbor = (check: Resources, harborType: HarborType) => (w: World): Result => {
+  const e = fail('The given resources do not match the harbor');
+  const s = success(w);
+  switch (harborType) {
+    case 'ClayHarbor':
+      return check.clay >= 2 ? s : e;
+    case 'GrainHarbor':
+      return check.grain >= 2 ? s : e;
+    case 'StoneHarbor':
+      return check.grain >= 2 ? s : e;
+    case 'WoodHarbor':
+      return check.grain >= 2 ? s : e;
+    case 'WoolHarbor':
+      return check.grain >= 2 ? s : e;
+    case 'ThreeToOneHarbor':
+      return check.clay >= 3 || check.grain >= 3 || check.stone >= 3 || check.wood >= 3 || check.wool >= 3 ? s : e;
+    default:
+      return fail('Undefined Harbor');
+  }
+};
+
+const playerHasHarbor = (playerName: string, harborType: HarborType) => (w: World): Result => {
+  const player = w.players[w.currentPlayer];
+  const tiles = w.map;
+  const hasHarbor = player.houses.some((house) => {
+    const hexes = neighbouringHexCoords(house.position);
+    return hexes.some((h) => {
+      const tile = tiles.find((t) => t.coord.x === h.x && t.coord.y === h.y);
+      return tile && tile.type === harborType;
+    });
+  });
+  if (!hasHarbor) {
+    return fail('You do not have a house on a harbor for this trade');
+  }
+  return success(w);
+};

--- a/colonists-shared/lib/Rules/MoveThiefDevelopmentCard.ts
+++ b/colonists-shared/lib/Rules/MoveThiefDevelopmentCard.ts
@@ -1,12 +1,19 @@
-import { Result } from '../Shared';
+import { Result, World, fail, success } from '../Shared';
 import { MoveThiefDevCardAction } from '../Action';
 import { ensureGameState,
   findPlayer,
-  developmentCardHasNotBeenPlayed,
   moveThief } from './Helpers';
+import { DevelopmentCard } from '../Entities/DevelopmentCard';
 
 export const MoveThiefDevelopmentCard = ({ parameters }: MoveThiefDevCardAction) => (w: Result): Result => w
   .flatMap(ensureGameState('Started'))
   .flatMap(findPlayer(parameters.playerName))
   .flatMap(developmentCardHasNotBeenPlayed(parameters.playedCard))
   .flatMap(moveThief(parameters.coordinates));
+
+const developmentCardHasNotBeenPlayed = (developmentCard: DevelopmentCard) => (w: World): Result => {
+  if (developmentCard.played) {
+    return fail('This card has already been played');
+  }
+  return success(w);
+};

--- a/colonists-shared/lib/Rules/PlayCard.ts
+++ b/colonists-shared/lib/Rules/PlayCard.ts
@@ -1,6 +1,9 @@
 import { PlayCardAction } from '../Action';
-import { Result } from '../Shared';
-import { ensureGameState, playCard, findPlayer } from './Helpers';
+import { DevelopmentCard } from '../Entities/DevelopmentCard';
+import { addResources, Resources } from '../Resources';
+import { Result, TileType, success, fail, World, Road } from '../Shared';
+import { ensureGameState, findPlayer, getResourceAmountOfType,
+  increasePointsForPlayer, setAmountOfResourceOfType } from './Helpers';
 
 export const PlayCard = ({ parameters }: PlayCardAction) => (
   w: Result,
@@ -14,3 +17,84 @@ export const PlayCard = ({ parameters }: PlayCardAction) => (
       parameters.chosenResources,
     ),
   );
+
+const playCard = (
+  playerName: string,
+  card: DevelopmentCard,
+  chosenResources?: [TileType] | [TileType, TileType],
+) => (w: World): Result => {
+  // Nasty... Couldn't see any other way.
+  // Clone existing card array, modify card played state.
+  const player = w.players.find((p) => p.name === playerName);
+  if (!player) return fail(`The player ${playerName} was not found`);
+  const devCards = player.devCards.slice();
+  const toPlay = devCards.find((c) => c.type === card.type && !c.played);
+  if (!toPlay) {
+    return fail('You do not have that card');
+  }
+
+  // Side effect!
+  toPlay.played = true;
+
+  if (card.type === 'Victory Point') {
+    return increasePointsForPlayer(playerName)(w);
+  }
+  if (card.type === 'Knight') {
+    const players = w.players.map((pl) => (pl.name === playerName ? {
+      ...pl, knights: pl.knights + 1, devCards,
+    } : pl));
+    return success({
+      ...w, players,
+    });
+  }
+  if (card.type === 'Road Building') {
+    const { resources } = player;
+    const roadCost = new Road().cost;
+    const withTwoExtraRoads = addResources(addResources(resources, roadCost), roadCost);
+    const players = w.players.map((pl) =>
+      pl.name === playerName ? {
+        ...pl, resources: withTwoExtraRoads, devCards,
+      } : pl);
+    return success({
+      ...w, players,
+    });
+  }
+  if (card.type === 'Year of Plenty') {
+    const chosen = chosenResources as [TileType, TileType];
+    if (!chosen) return fail('You must choose resources to play this card');
+    const { resources } = player;
+    const firstToReceive = getResourceAmountOfType(chosen[0], resources) + 1;
+    const first = setAmountOfResourceOfType(firstToReceive, resources, chosen[0]);
+    const secondToReceive = getResourceAmountOfType(chosen[1], first) + 1;
+    const second = setAmountOfResourceOfType(secondToReceive, first, chosen[1]);
+    const players = w.players.map((pl) =>
+      (pl.name === playerName ? {
+        ...pl, resources: second, devCards,
+      } : pl));
+
+    return success({
+      ...w, players,
+    });
+  }
+  if (card.type === 'Monopoly') {
+    const allOthersResources = w.players
+      .filter((p) => p.name !== playerName)
+      .reduce((acc, p) => acc.concat(p.resources), [] as Resources[]);
+    const chosenType = chosenResources as [TileType];
+    const toReceive = allOthersResources
+      .reduce((acc, rr) => acc + getResourceAmountOfType(chosenType[0], rr), 0);
+    const added = setAmountOfResourceOfType(toReceive, player.resources, chosenType[0]);
+    const players = w.players.map((pl) =>
+      pl.name === playerName
+        ? {
+          ...pl, resources: added,
+        }
+        : {
+          ...pl, resources: setAmountOfResourceOfType(0, pl.resources, chosenType[0]),
+        });
+    return success({
+      ...w, players,
+    });
+  }
+  return fail('You tried to play an invalid card');
+};

--- a/colonists-shared/lib/Shared.ts
+++ b/colonists-shared/lib/Shared.ts
@@ -13,7 +13,7 @@ import { Road } from './Entities/Road';
 import { House } from './Entities/House';
 import { City } from './Entities/City';
 import { Purchaseable } from './Entities/Purchaseable';
-import { Tile, TileType, DiceRollType } from './Tile';
+import { Tile, TileType, DiceRoll } from './Tile';
 import { World, GameState } from './World';
 import { GameRules } from './GameRules';
 import { GameStatistics } from './GameStatistics';
@@ -43,7 +43,7 @@ export {
   Road,
   Tile,
   TileType,
-  DiceRollType,
+  DiceRoll,
   Result,
   World,
   GameRules,

--- a/colonists-shared/lib/Tile.ts
+++ b/colonists-shared/lib/Tile.ts
@@ -16,7 +16,7 @@ export type TileType =
   | 'Desert'
   | 'Ocean'
   | HarborType;
-export type DiceRollType =
+export type DiceRoll =
   | 'None'
   | 2
   | 3
@@ -43,6 +43,6 @@ export type GeneratorDiceRollType =
   | 12;
 export interface Tile {
   type: TileType;
-  diceRoll: DiceRollType;
+  diceRoll: DiceRoll;
   coord: HexCoordinate;
 }

--- a/colonists-shared/lib/World.ts
+++ b/colonists-shared/lib/World.ts
@@ -1,6 +1,6 @@
 import { Player } from './Player';
 import { Thief } from './Thief';
-import { Tile, DiceRollType } from './Tile';
+import { Tile, DiceRoll } from './Tile';
 import { GameRules } from './GameRules';
 import { GameStatistics } from './GameStatistics';
 
@@ -8,7 +8,7 @@ export type GameState = 'Uninitialized' | 'Pregame' | 'Started' | 'Finished';
 
 export interface World {
   currentPlayer: number;
-  currentDie: DiceRollType;
+  currentDie: DiceRoll;
   players: Player[];
   thief?: Thief;
   lastThiefPosition?: Thief;


### PR DESCRIPTION
Move non-shared functions to corresponding rules, rename DiceRollType
- All the functions in Helper.ts have been moved to the rule the were only used from
- Some nearly identical functions were refactored to avoid repetition
- DiceRollType has been renamed to DiceRoll, leading to client changes
- WARN has been added as a warning for comments (we shouldn't have "//WARN" lying around)
- Tests have been changed according to refactor