### PR TITLE
Implement valid map generation (fixes #1214)

### DIFF
--- a/colonists-client/src/components/CustomizeGame.vue
+++ b/colonists-client/src/components/CustomizeGame.vue
@@ -26,6 +26,7 @@
           <v-col sm="3">
             <v-text-field
               v-model="numberOfIslands"
+              disabled
               dark
               outlined
               dense

--- a/colonists-shared/lib/Tile.ts
+++ b/colonists-shared/lib/Tile.ts
@@ -29,18 +29,6 @@ export type DiceRoll =
   | 10
   | 11
   | 12;
-export type GeneratorDiceRollType =
-  | 'None'
-  | 2
-  | 3
-  | 4
-  | 5
-  | 6
-  | 8
-  | 9
-  | 10
-  | 11
-  | 12;
 export interface Tile {
   type: TileType;
   diceRoll: DiceRoll;


### PR DESCRIPTION
This removes the probability-based map generation and instead shuffles a deck of simulated tiles/chits/harbors according to the real game.