### PR TITLE
Issue/1218 fix world gen harbor location

### DIFF
--- a/colonists-shared/lib/HexCoordinate.ts
+++ b/colonists-shared/lib/HexCoordinate.ts
@@ -5,48 +5,56 @@ export interface HexCoordinate {
   y: number;
 }
 
-export const getNeighbouringHexCoords = (
-  coord: HexCoordinate,
-): HexCoordinate[] => {
+export function hexEquals(hex1: HexCoordinate, hex2: HexCoordinate) {
+  return hex1.x === hex2.x && hex1.y === hex2.y;
+}
+
+export const getNeighbouringHexCoords = (coord: HexCoordinate): HexCoordinate[] => {
   let result = [
     {
-      x: coord.x, y: coord.y - 1,
+      x: coord.x,
+      y: coord.y - 1,
     },
     {
-      x: coord.x, y: coord.y + 1,
+      x: coord.x,
+      y: coord.y + 1,
     },
     {
-      x: coord.x - 1, y: coord.y,
+      x: coord.x - 1,
+      y: coord.y,
     },
     {
-      x: coord.x + 1, y: coord.y,
+      x: coord.x + 1,
+      y: coord.y,
     },
   ];
   if (coord.x % 2 === 0) {
     result = result.concat([
       {
-        x: coord.x - 1, y: coord.y - 1,
+        x: coord.x - 1,
+        y: coord.y - 1,
       },
       {
-        x: coord.x + 1, y: coord.y - 1,
+        x: coord.x + 1,
+        y: coord.y - 1,
       },
     ]);
   } else {
     result = result.concat([
       {
-        x: coord.x - 1, y: coord.y + 1,
+        x: coord.x - 1,
+        y: coord.y + 1,
       },
       {
-        x: coord.x + 1, y: coord.y + 1,
+        x: coord.x + 1,
+        y: coord.y + 1,
       },
     ]);
   }
   return result;
 };
 
-export const getNeighbouringMatrixCoords = (
-  coord: HexCoordinate,
-): MatrixCoordinate[] => {
+export const getNeighbouringMatrixCoords = (coord: HexCoordinate): MatrixCoordinate[] => {
   const matrixX = coord.x * 2;
   let matrixY = coord.y * 2 + 1;
   if (coord.x % 2 !== 0) {
@@ -54,30 +62,33 @@ export const getNeighbouringMatrixCoords = (
   }
   return [
     {
-      x: matrixX + 3, y: matrixY,
+      x: matrixX + 3,
+      y: matrixY,
     },
     {
-      x: matrixX + 2, y: matrixY + 1,
+      x: matrixX + 2,
+      y: matrixY + 1,
     },
     {
-      x: matrixX + 1, y: matrixY + 1,
+      x: matrixX + 1,
+      y: matrixY + 1,
     },
     {
-      x: matrixX, y: matrixY,
+      x: matrixX,
+      y: matrixY,
     },
     {
-      x: matrixX + 1, y: matrixY - 1,
+      x: matrixX + 1,
+      y: matrixY - 1,
     },
     {
-      x: matrixX + 2, y: matrixY - 1,
+      x: matrixX + 2,
+      y: matrixY - 1,
     },
   ];
 };
 
-export const getMatrixCoordCorner = (
-  coord: HexCoordinate,
-  cornerIndex: number,
-): MatrixCoordinate => {
+export const getMatrixCoordCorner = (coord: HexCoordinate, cornerIndex: number): MatrixCoordinate => {
   const matrixX = coord.x * 2;
   let matrixY = coord.y * 2 + 1;
   if (coord.x % 2 !== 0) {
@@ -86,27 +97,33 @@ export const getMatrixCoordCorner = (
   switch (cornerIndex) {
     case 0:
       return {
-        x: matrixX + 3, y: matrixY,
+        x: matrixX + 3,
+        y: matrixY,
       };
     case 1:
       return {
-        x: matrixX + 2, y: matrixY + 1,
+        x: matrixX + 2,
+        y: matrixY + 1,
       };
     case 2:
       return {
-        x: matrixX + 1, y: matrixY + 1,
+        x: matrixX + 1,
+        y: matrixY + 1,
       };
     case 3:
       return {
-        x: matrixX, y: matrixY,
+        x: matrixX,
+        y: matrixY,
       };
     case 4:
       return {
-        x: matrixX + 1, y: matrixY - 1,
+        x: matrixX + 1,
+        y: matrixY - 1,
       };
     case 5:
       return {
-        x: matrixX + 2, y: matrixY - 1,
+        x: matrixX + 2,
+        y: matrixY - 1,
       };
     default:
       throw Error('Corner index out of bounds');

--- a/colonists-shared/lib/Tile.ts
+++ b/colonists-shared/lib/Tile.ts
@@ -1,4 +1,4 @@
-import { HexCoordinate } from './HexCoordinate';
+import { HexCoordinate, hexEquals } from './HexCoordinate';
 
 export type HarborType =
   | 'WoodHarbor'
@@ -7,30 +7,14 @@ export type HarborType =
   | 'ClayHarbor'
   | 'StoneHarbor'
   | 'ThreeToOneHarbor';
-export type TileType =
-  | 'Wood'
-  | 'Stone'
-  | 'Clay'
-  | 'Grain'
-  | 'Wool'
-  | 'Desert'
-  | 'Ocean'
-  | HarborType;
-export type DiceRoll =
-  | 'None'
-  | 2
-  | 3
-  | 4
-  | 5
-  | 6
-  | 7
-  | 8
-  | 9
-  | 10
-  | 11
-  | 12;
+export type TileType = 'Wood' | 'Stone' | 'Clay' | 'Grain' | 'Wool' | 'Desert' | 'Ocean' | HarborType;
+export type DiceRoll = 'None' | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
 export interface Tile {
   type: TileType;
   diceRoll: DiceRoll;
   coord: HexCoordinate;
+}
+
+export function findTileInMap(map: Tile[], hex: HexCoordinate): Tile | undefined {
+  return map.find((x) => hexEquals(x.coord, hex));
 }


### PR DESCRIPTION
Fixes #1218 .

Changes the world generation logic:

- Use generators to more cleanly handle mutation of list of possible tiles to place.
- First place water tiles. Then pick a starting location, and BFS out from that every ocean tiles. If an ocean tile does not have a harbor as neighbor, change the ocean tile to harbor. 

Unfortunately this solution relies on mutation of the map, which I would rather not have implemented - but I don't see a way around it.

